### PR TITLE
fix: Fixed typo in JSDoc @category tag: ath → Math

### DIFF
--- a/docs/ko/core-concept.md
+++ b/docs/ko/core-concept.md
@@ -38,7 +38,7 @@ Docflow는 일관된 문서 생성을 위해 표준화된 JSDoc 템플릿을 사
 /**
  * @public
  * @kind function
- * @category ath
+ * @category Math
  * @name calculateArea
  * @signature
  * ```typescript


### PR DESCRIPTION
## 📝 Changes
- Fixed typo in JSDoc @category tag: `ath` → `Math`

## 🎯 Reason for Change
- Corrected the function category name from the incorrectly written `ath` to the proper `Math`
- Required for accurate category classification during documentation generation