### PR TITLE
fix: correct workspace filtering example in documentation

### DIFF
--- a/docs/en/config.md
+++ b/docs/en/config.md
@@ -166,8 +166,8 @@ workspace: {
 // Filters as follows:
 // ✅ packages/core -> included
 // ✅ packages/ui -> included
+// ✅ apps/web -> included
 // ❌ packages/internal-utils -> excluded
-// ❌ apps/web -> excluded (not in include)
 ```
 
 ## commands.build Configuration

--- a/docs/ko/config.md
+++ b/docs/ko/config.md
@@ -118,8 +118,8 @@ project: {
 // 다음과 같이 필터링:
 // ✅ packages/core -> 포함
 // ✅ packages/ui -> 포함
+// ✅ apps/web -> 포함
 // ❌ packages/internal-utils -> 제외
-// ❌ apps/web -> 제외 (include에 없음)
 ```
 
 ## commands.build 설정


### PR DESCRIPTION
## 🐛 Fix Documentation Error

### Problem
The `project.workspace` documentation contains an incorrect filtering example. The comment shows `apps/web` as excluded with the reason "(include에 없음)" (not in include), but this is wrong since `apps/web` matches the `apps/*` pattern in the include array.

### Solution
Corrected the filtering example to accurately reflect the workspace configuration:

**Before:**
```js
project: {
  workspace: {
    include: ["packages/*", "apps/*"], // 포함할 패턴
    exclude: ["packages/internal-*"]   // 제외할 패턴
  }
}
// 다음과 같이 필터링:
// ✅ packages/core -> 포함
// ✅ packages/ui -> 포함
// ❌ packages/internal-utils -> 제외
// ❌ apps/web -> 제외 (include에 없음)
```


**After:**
```js
project: {
  workspace: {
    include: ["packages/*", "apps/*"], // 포함할 패턴
    exclude: ["packages/internal-*"]   // 제외할 패턴
  }
}
// 다음과 같이 필터링:
// ✅ packages/core -> 포함
// ✅ packages/ui -> 포함
// ✅ apps/web -> 포함
// ❌ packages/internal-utils -> 제외
```

### Changes
- Fixed the workspace filtering example comment
- Updated the result to show `apps/web` as included, not excluded

This ensures developers have accurate information about how workspace filtering works with glob patterns.