### PR TITLE
fix: rename parameters to properties in config type docs

### DIFF
--- a/docs/en/reference/cli/Configuration/Config.md
+++ b/docs/en/reference/cli/Configuration/Config.md
@@ -14,7 +14,7 @@ Type for Docflow configuration files. Includes project settings, command setting
 type Config = z.infer<typeof configSchema>;
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Generator/GeneratedDoc.md
+++ b/docs/en/reference/cli/Generator/GeneratedDoc.md
@@ -16,7 +16,7 @@ interface GeneratedDoc {
 }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Generator/GeneratorConfig.md
+++ b/docs/en/reference/cli/Generator/GeneratorConfig.md
@@ -24,7 +24,7 @@ interface GeneratorConfig { name: string; projectRoot: string; labels?: {
   }; signatureLanguage?: string }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Generator/MarkdownDocument.md
+++ b/docs/en/reference/cli/Generator/MarkdownDocument.md
@@ -14,7 +14,7 @@ Structure representing a complete Markdown document with optional frontmatter an
 interface MarkdownDocument { frontmatter?: Record<string, unknown>; sections: MarkdownSection[] }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Generator/MarkdownGenerator.md
+++ b/docs/en/reference/cli/Generator/MarkdownGenerator.md
@@ -17,7 +17,7 @@ interface MarkdownGenerator { generate(jsDocData: ParsedJSDoc, sourcePath?: stri
   ): GeneratedDoc }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Generator/MarkdownSection.md
+++ b/docs/en/reference/cli/Generator/MarkdownSection.md
@@ -14,7 +14,7 @@ Interface representing a section of a Markdown document.
 interface MarkdownSection { type: MarkdownSectionType; content: string }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Manifest/SidebarItem.md
+++ b/docs/en/reference/cli/Manifest/SidebarItem.md
@@ -14,7 +14,7 @@ Represents a sidebar navigation item for the documentation site. Can be a link o
 interface SidebarItem { text: string; link?: string; items?: SidebarItem[]; collapsed?: boolean }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/ExampleData.md
+++ b/docs/en/reference/cli/Parser/ExampleData.md
@@ -14,7 +14,7 @@ Represents the parsed result of @example tags in JSDoc.
 interface ExampleData { title?: string; code: string; language?: string }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/ExportDeclaration.md
+++ b/docs/en/reference/cli/Parser/ExportDeclaration.md
@@ -19,7 +19,7 @@ type ExportDeclaration = {
 };
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/ParameterData.md
+++ b/docs/en/reference/cli/Parser/ParameterData.md
@@ -14,7 +14,7 @@ Represents the parsed result of @param tags in JSDoc.
 interface ParameterData { name: string; type: string; description: string; required: boolean; defaultValue?: string; nested?: ParameterData[] }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/ParsedJSDoc.md
+++ b/docs/en/reference/cli/Parser/ParsedJSDoc.md
@@ -14,7 +14,7 @@ Represents the parsed result of JSDoc templates used in Docflow.
 interface ParsedJSDoc { name?: string; description?: string; category?: string; kind?: string; signature?: string; deprecated?: string; examples?: ExampleData[]; parameters?: ParameterData[]; returns?: ReturnData; throws?: ThrowsData[]; typedef?: TypedefData[]; see?: SeeData[]; version?: VersionData[] }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/ReturnData.md
+++ b/docs/en/reference/cli/Parser/ReturnData.md
@@ -14,7 +14,7 @@ Represents the parsed result of @returns tags in JSDoc. Used to describe return 
 interface ReturnData { type: string; name?: string; description: string; properties?: PropertyData[] }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/SeeData.md
+++ b/docs/en/reference/cli/Parser/SeeData.md
@@ -14,7 +14,7 @@ Represents the parsed result of @see tags in JSDoc. Used to provide references t
 interface SeeData { reference: string; description?: string }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/TargetWithJSDoc.md
+++ b/docs/en/reference/cli/Parser/TargetWithJSDoc.md
@@ -14,7 +14,7 @@ interface TargetWithJSDoc extends ExportDeclaration {
 }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/ThrowsData.md
+++ b/docs/en/reference/cli/Parser/ThrowsData.md
@@ -14,7 +14,7 @@ Represents the parsed result of @throws tags in JSDoc. Used to describe exceptio
 interface ThrowsData { type: string; name?: string; description: string }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/TypedefData.md
+++ b/docs/en/reference/cli/Parser/TypedefData.md
@@ -14,7 +14,7 @@ Represents the parsed result of @typedef tags in JSDoc. Used to define custom ty
 interface TypedefData { name: string; type: string; description: string; properties: PropertyData[] }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Parser/VersionData.md
+++ b/docs/en/reference/cli/Parser/VersionData.md
@@ -14,7 +14,7 @@ Represents the parsed result of @version tags in JSDoc. Used to display version 
 interface VersionData { version: string; description: string; platforms?: string[] }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Plugin/Plugin.md
+++ b/docs/en/reference/cli/Plugin/Plugin.md
@@ -20,7 +20,7 @@ interface Plugin { name: string; hooks: {
   } }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/en/reference/cli/Plugin/PluginContext.md
+++ b/docs/en/reference/cli/Plugin/PluginContext.md
@@ -14,7 +14,7 @@ Context information passed during plugin execution. Includes workspace path and 
 interface PluginContext { workspacePath?: string; config?: Config }
 ```
 
-### Parameters
+### Properties
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Configuration/Config.md
+++ b/docs/ko/reference/cli/Configuration/Config.md
@@ -14,7 +14,7 @@ Docflow의 설정 타입이에요. 프로젝트 설정, 명령어 설정, 플러
 type Config = z.infer<typeof configSchema>;
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Generator/GeneratedDoc.md
+++ b/docs/ko/reference/cli/Generator/GeneratedDoc.md
@@ -14,7 +14,7 @@ sourcePath: "packages/cli/src/core/types/generator.types.ts"
 interface GeneratedDoc { filePath: StandardizedFilePath; content: string; relativePath: string }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Generator/GeneratorConfig.md
+++ b/docs/ko/reference/cli/Generator/GeneratorConfig.md
@@ -24,7 +24,7 @@ interface GeneratorConfig { name: string; projectRoot: string; labels?: {
   }; signatureLanguage?: string }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Generator/MarkdownDocument.md
+++ b/docs/ko/reference/cli/Generator/MarkdownDocument.md
@@ -14,7 +14,7 @@ sourcePath: "packages/cli/src/core/types/generator.types.ts"
 interface MarkdownDocument { frontmatter?: Record<string, unknown>; sections: MarkdownSection[] }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Generator/MarkdownGenerator.md
+++ b/docs/ko/reference/cli/Generator/MarkdownGenerator.md
@@ -17,7 +17,7 @@ interface MarkdownGenerator { generate(jsDocData: ParsedJSDoc, sourcePath?: stri
   ): GeneratedDoc }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Generator/MarkdownSection.md
+++ b/docs/ko/reference/cli/Generator/MarkdownSection.md
@@ -14,7 +14,7 @@ Markdown 문서의 섹션을 나타내는 인터페이스에요.
 interface MarkdownSection { type: MarkdownSectionType; content: string }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Manifest/SidebarItem.md
+++ b/docs/ko/reference/cli/Manifest/SidebarItem.md
@@ -14,7 +14,7 @@ sourcePath: "packages/cli/src/commands/build/manifest/manifest.ts"
 interface SidebarItem { text: string; link?: string; items?: SidebarItem[]; collapsed?: boolean }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/ExampleData.md
+++ b/docs/ko/reference/cli/Parser/ExampleData.md
@@ -14,7 +14,7 @@ JSDoc에서 @example 태그를 파싱한 결과를 나타내요.
 interface ExampleData { title?: string; code: string; language?: string }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/ExportDeclaration.md
+++ b/docs/ko/reference/cli/Parser/ExportDeclaration.md
@@ -21,7 +21,7 @@ type ExportDeclaration = {
 };
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/ParameterData.md
+++ b/docs/ko/reference/cli/Parser/ParameterData.md
@@ -14,7 +14,7 @@ JSDoc에서 @param 태그를 파싱한 결과를 나타내요.
 interface ParameterData { name: string; type: string; description: string; required: boolean; defaultValue?: string; nested?: ParameterData[] }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/ParsedJSDoc.md
+++ b/docs/ko/reference/cli/Parser/ParsedJSDoc.md
@@ -14,7 +14,7 @@ Docflow에서 사용하는 JSDoc 템플릿을 파싱한 결과를 나타내요.
 interface ParsedJSDoc { name?: string; description?: string; category?: string; kind?: string; signature?: string; deprecated?: string; examples?: ExampleData[]; parameters?: ParameterData[]; returns?: ReturnData; throws?: ThrowsData[]; typedef?: TypedefData[]; see?: SeeData[]; version?: VersionData[] }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/ReturnData.md
+++ b/docs/ko/reference/cli/Parser/ReturnData.md
@@ -14,7 +14,7 @@ JSDoc에서 @returns 태그를 파싱한 결과를 나타내요. 함수의 반�
 interface ReturnData { type: string; name?: string; description: string; properties?: PropertyData[] }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/SeeData.md
+++ b/docs/ko/reference/cli/Parser/SeeData.md
@@ -14,7 +14,7 @@ JSDoc에서 @see 태그를 파싱한 결과를 나타내요. 외부 문서나 �
 interface SeeData { reference: string; description?: string }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/TargetWithJSDoc.md
+++ b/docs/ko/reference/cli/Parser/TargetWithJSDoc.md
@@ -14,7 +14,7 @@ interface TargetWithJSDoc extends ExportDeclaration {
 }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/ThrowsData.md
+++ b/docs/ko/reference/cli/Parser/ThrowsData.md
@@ -14,7 +14,7 @@ JSDoc에서 @throws 태그를 파싱한 결과를 나타내요. 함수에서 발
 interface ThrowsData { type: string; name?: string; description: string }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/TypedefData.md
+++ b/docs/ko/reference/cli/Parser/TypedefData.md
@@ -14,7 +14,7 @@ JSDoc에서 @typedef 태그를 파싱한 결과를 나타내요. 사용자 정�
 interface TypedefData { name: string; type: string; description: string; properties: PropertyData[] }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Parser/VersionData.md
+++ b/docs/ko/reference/cli/Parser/VersionData.md
@@ -14,7 +14,7 @@ JSDoc에서 @version 태그를 파싱한 결과를 나타내요. 버전 정보�
 interface VersionData { version: string; description: string; platforms?: string[] }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Plugin/Plugin.md
+++ b/docs/ko/reference/cli/Plugin/Plugin.md
@@ -20,7 +20,7 @@ interface Plugin { name: string; hooks: {
   } }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">

--- a/docs/ko/reference/cli/Plugin/PluginContext.md
+++ b/docs/ko/reference/cli/Plugin/PluginContext.md
@@ -14,7 +14,7 @@ sourcePath: "packages/cli/src/plugins/types/plugin.types.ts"
 interface PluginContext { workspacePath?: string; config?: Config }
 ```
 
-### 매개변수
+### 속성
 
 <ul class="post-parameters-ul">
   <li class="post-parameters-li post-parameters-li-root">


### PR DESCRIPTION
## 🐛 Fix Incorrect Terminology in Type Documentation

### Problem
Multiple TypeScript type documentation files incorrectly use `매개변수(parameters)` to describe type structures. Since these are TypeScript type definitions, not functions, these should be called `속성(properties)` instead.


### Changes
- Changed section title from `매개변수` to `속성` across multiple type documentation files(ko)
- Changed section title from `Parameters` to `Properties` across multiple type documentation files(en)
- Maintained all existing CSS classes and structure
- No functional changes to the documentation layout

### Why This Matters
Using correct terminology helps developers understand that:
- These are type definitions with properties
- Not a function with parameters
- Improves overall documentation accuracy and clarity

This change aligns the documentation with standard TypeScript terminology conventions.