### PR TITLE
docs: fix incorrect variable name in tutorial code example

### DIFF
--- a/docs/en/tutorial.md
+++ b/docs/en/tutorial.md
@@ -214,7 +214,7 @@ export default defineConfig({
     sidebar: [
       {
         text: "Reference",
-        items: reference,
+        items: manifest,
       },
     ],
   },

--- a/docs/ko/tutorial.md
+++ b/docs/ko/tutorial.md
@@ -218,7 +218,7 @@ export default defineConfig({
     sidebar: [
       {
         text: "레퍼런스",
-        items: reference,
+        items: manifest,
       },
     ],
   },


### PR DESCRIPTION
  ## Summary

  - Fix `items: reference` → `items: manifest` in both English and Korean tutorial code examples
  - The code imports `manifest` from `manifest.json` but incorrectly references an undefined `reference` variable, which would cause `ReferenceError` if copied as-is

  ## Affected files

  - `docs/en/tutorial.md`
  - `docs/ko/tutorial.md`